### PR TITLE
Removing %NAME%/ from Working Paths

### DIFF
--- a/Xerox/FieryEX550_560_ElCapitan.pkg.recipe
+++ b/Xerox/FieryEX550_560_ElCapitan.pkg.recipe
@@ -34,7 +34,7 @@
                 <key>flat_pkg_path</key>
                 <string>%RECIPE_CACHE_DIR%/downloads/XC_EX560_v1_1_RX_FD50_v1.dmg/Fiery Printer Driver.pkg</string>
                 <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/Unpacked</string>
+                <string>%RECIPE_CACHE_DIR%/Unpacked</string>
                 <key>purge_destination</key>
                 <true/>
             </dict>
@@ -59,7 +59,7 @@
             <key>Arguments</key>
             <dict>
                 <key>pkg_payload_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/Unpacked/FieryPrinterDriverInstaller.pkg/Payload</string>
+                <string>%RECIPE_CACHE_DIR%/Unpacked/FieryPrinterDriverInstaller.pkg/Payload</string>
                 <key>destination_path</key>
                 <string>%RECIPE_CACHE_DIR%/pkgroot/tmp/Fiery Printer Driver Installer.app</string>
             </dict>
@@ -85,7 +85,7 @@
                     <key>version</key>
                     <string>2.0</string>
                     <key>scripts</key>
-                    <string>%RECIPE_CACHE_DIR%/%NAME%/Unpacked/FieryPrinterDriverInstaller.pkg/Scripts</string>
+                    <string>%RECIPE_CACHE_DIR%/Unpacked/FieryPrinterDriverInstaller.pkg/Scripts</string>
                     <key>chown</key>
                     <array>
                     </array>


### PR DESCRIPTION
In it's current state FieryEX550_560_ElCapitan.pkg.recipe fails since:

~/Library/AutoPkg/Cache/com.github.mosen.pkg.FieryEX550_560_ElCapitan/FieryEX550_560_ElCapitan

doesn't exist.  The verbose log in part:

####
FlatPkgUnpacker: Mounted disk image /Users/admin/Library/AutoPkg/Cache/com.github.mosen.pkg.FieryEX550_560_ElCapitan/downloads/XC_EX560_v1_1_RX_FD50_v1.dmg
Can't create /Users/admin/Library/AutoPkg/Cache/com.github.mosen.pkg.FieryEX550_560_ElCapitan/FieryEX550_560_ElCapitan/Unpacked: No such file or directory
Failed.
Receipt written to /Users/admin/Library/AutoPkg/Cache/com.github.mosen.pkg.FieryEX550_560_ElCapitan/receipts/FieryEX550_560_ElCapitan-receipt-20151212-210915.plist

The following recipes failed:
    FieryEX550_560_ElCapitan.pkg
        Error in com.github.mosen.pkg.FieryEX550_560_ElCapitan: Processor: FlatPkgUnpacker: Error: Can't create /Users/admin/Library/AutoPkg/Cache/com.github.mosen.pkg.FieryEX550_560_ElCapitan/FieryEX550_560_ElCapitan/Unpacked: No such file or directory

Nothing downloaded, packaged or imported.
####

This appears to be because FlatPkgUnpacker (and perhaps older python) cannot gracefully handle creating more than one level/depth of target directory, and FlatPkgUnpacker has a not-yet-created two levels deep destination of "%NAME%/Unpacked" in the destination_path of "%RECIPE_CACHE_DIR%/%NAME%/Unpacked".

Changing the various lines that refer to the "%NAME%" directory appear to make the recipe work without affecting the package that's output.