### PR TITLE
Sparkle download, code sig verification, and Munki simplification

### DIFF
--- a/XRite/PantoneColorManager.download.recipe
+++ b/XRite/PantoneColorManager.download.recipe
@@ -13,6 +13,7 @@
     via spectrophotometer.
 
     2015-12-22: Added Static URL to override Sparkle URL because pantone have let the certificate expire on pcm.pantone.com
+    2019-02-15: Re-introducing SparkleUpdateInfoProvider because certificate is back in working order, and now points directly to a dmg, which simplifies the Munki recipe
 
     </string>
     <key>Identifier</key>
@@ -21,25 +22,45 @@
     <dict>
         <key>NAME</key>
         <string>PantoneColorManager</string>
+        <key>SPARKLE_FEED_URL</key>
+        <string>https://pcm.pantone.com/pantonecolormanager/mac/feed/pcm_feed.xml</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.0</string>
     <key>Process</key>
     <array>
         <dict>
-            <key>Processor</key>
-            <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>
-                <key>url</key>
-                <string>http://www.pantone.com/downloads/support/macfiles/PANTONE_COLOR_MANAGER_MAC.zip</string>
-                <key>filename</key>
-                <string>%NAME%.zip</string>
+                <key>appcast_url</key>
+                <string>%SPARKLE_FEED_URL%</string>
             </dict>
+            <key>Processor</key>
+            <string>SparkleUpdateInfoProvider</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>filename</key>
+                <string>%NAME%-%version%.dmg</string>
+            </dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
         </dict>
         <dict>
             <key>Processor</key>
             <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%pathname%/PANTONE Color Manager.app</string>
+                <key>requirement</key>
+                <string>anchor apple generic and identifier "com.xrite.pantonecolormanager" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2K7GT73B4R")</string>
+            </dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
         </dict>
     </array>
 </dict>

--- a/XRite/PantoneColorManager.munki.recipe
+++ b/XRite/PantoneColorManager.munki.recipe
@@ -32,10 +32,14 @@
             </array>
             <key>description</key>
             <string>COLOR MANAGER Software is a robust desktop application that provides the assurance and confidence to use the latest PANTONE Colors accurately.</string>
+            <key>developer</key>
+            <string>X-Rite</string>
             <key>display_name</key>
             <string>PANTONE Color Manager</string>
             <key>name</key>
             <string>%NAME%</string>
+            <key>unattended_install</key>
+            <true/>
         </dict>
     </dict>
     <key>MinimumVersion</key>
@@ -45,23 +49,10 @@
     <key>Process</key>
     <array>
         <dict>
-            <key>Processor</key>
-            <string>Unarchiver</string>
-            <key>Arguments</key>
-            <dict>
-                <key>archive_path</key>
-                <string>%pathname%</string>
-                <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%</string>
-                <key>purge_destination</key>
-                <true/>
-            </dict>
-        </dict>
-        <dict>
             <key>Arguments</key>
             <dict>
                 <key>pkg_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.pkg</string>
+                <string>%pathname%</string>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
             </dict>


### PR DESCRIPTION
This re-introduces the Sparkle feed download for Pantone Color Manager, which now points to a dmg containing an app, rather than the direct download that used to point to a zip containing a pkg.

Code signature verification has also been added to ensure the app is signed as expected.

There are two potential downsides to this change:
- The server at `pcm.pantone.com` seems noticeably slower than the previous download link at `www.pantone.com`. I'm OK with waiting a bit longer for the dmg download.
- From what I can gather from the description, the previous pkg-in-zip included some additional components ("X-Rite Device Services") that this new app-in-dmg might not include.