### PR TITLE
Removing period that breaks child recipes

### DIFF
--- a/Esko/DeskpackEssentials.download.recipe
+++ b/Esko/DeskpackEssentials.download.recipe
@@ -9,7 +9,7 @@
     You must register to receive the download URL
     </string>
     <key>Identifier</key>
-    <string>com.github.mosen.download.Esko.DeskpackEssentials</string>
+    <string>com.github.mosen.download.EskoDeskpackEssentials</string>
     <key>Input</key>
     <dict>
         <key>NAME</key>


### PR DESCRIPTION
The .pkg and .munki recipes for this title use the identifier com.github.mosen.download.EskoDeskpackEssentials. This recipe uses com.github.mosen.download.Esko.DeskpackEssentials, causing Autopkg to not be able to find parent recipes.

Could also be fixed by going the other way and adding the period to .pkg and .munki recipes. I am happy to submit those changes if preferred.