### PR TITLE
Call path to uninstall script directly

### DIFF
--- a/Centrify/CentrifyDC.munki.recipe
+++ b/Centrify/CentrifyDC.munki.recipe
@@ -44,15 +44,9 @@
             <key>unattended_install</key>
             <true/>
             <key>uninstall_method</key>
-            <string>uninstall_script</string>
-            <key>uninstall_script</key>
-            <string>
-                #!/bin/sh
-                # Automatically unbinds from domain and uninstalls agent.
-                /usr/share/centrifydc/bin/uninstall.sh
-            </string>
+            <string>/usr/share/centrifydc/bin/uninstall.sh</string>
             <key>uninstallable</key>
-            <true/>    
+            <true/>
         </dict>
     </dict>
     <key>MinimumVersion</key>


### PR DESCRIPTION
According to the Munki wiki, the possible values for `uninstall_method` include one of:

- removepackages
- remove_copied_items
- remove_app
- uninstall_script
- remove_profile
- one of the "Adobe*" removal methods
- **the absolute path to a local script**

https://github.com/munki/munki/wiki/Supported-Pkginfo-Keys

So there's no need to set `uninstall_script` as the method; just use the path to the script itself.