### PR TITLE
Basic python3 compatibility

### DIFF
--- a/Adobe/AcrobatProCustomizationWizardRunner.py
+++ b/Adobe/AcrobatProCustomizationWizardRunner.py
@@ -19,16 +19,15 @@
 # https://gist.github.com/timsutton/212bfed9da2056a070a12ac27febeb71
 
 from __future__ import absolute_import
+
 import os
 import plistlib
 import subprocess
 import tempfile
 
-from pprint import pprint
-
+import FoundationPlist
 from autopkglib import Processor, ProcessorError
 from autopkglib.DmgMounter import DmgMounter
-from autopkglib import FoundationPlist
 
 __all__ = ["AcrobatProCustomizationWizardRunner"]
 

--- a/Adobe/AcrobatProCustomizationWizardRunner.py
+++ b/Adobe/AcrobatProCustomizationWizardRunner.py
@@ -18,6 +18,7 @@
 # Based on a simple Customization Wrapper script from:
 # https://gist.github.com/timsutton/212bfed9da2056a070a12ac27febeb71
 
+from __future__ import absolute_import
 import os
 import plistlib
 import subprocess

--- a/Adobe/AdobeProvisioningToolkitProvider.py
+++ b/Adobe/AdobeProvisioningToolkitProvider.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python
 
 from __future__ import absolute_import
+
 import os.path
 import subprocess
+
 from autopkglib import Processor, ProcessorError
 
 __all__ = ["AdobeProvisioningToolkitProvider"]

--- a/Adobe/AdobeProvisioningToolkitProvider.py
+++ b/Adobe/AdobeProvisioningToolkitProvider.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 import os.path
 import subprocess
 from autopkglib import Processor, ProcessorError

--- a/Adobe/LightroomURLProvider.py
+++ b/Adobe/LightroomURLProvider.py
@@ -39,10 +39,10 @@ LIGHTROOM_PRODUCT_URL = "http://www.adobe.com/go/lightroom_%s_updates_%s_%s"
 ADOBE_DOWNLOAD_PREFIX = "http://www.adobe.com/support/downloads"
 MAJOR_VERSION_DEFAULT = "5"
 
-RE_VERSION = 'versionString\s=\s"([^"]*)"'
-RE_PRODUCT_URL = 'downloadURL\s=\s(.*)' # Can substitute variables later
-RE_LOCAL_DESCRIPTION = '%s\s=\s\{^([^}]*)}' # Must be multi line
-RE_HTML_DOWNLOAD_URL = '<a class="submit[^"]*"\shref="([^"]*)"'
+RE_VERSION = r'versionString\s=\s"([^"]*)"'
+RE_PRODUCT_URL = r'downloadURL\s=\s(.*)' # Can substitute variables later
+RE_LOCAL_DESCRIPTION = r'%s\s=\s\{^([^}]*)}' # Must be multi line
+RE_HTML_DOWNLOAD_URL = r'<a class="submit[^"]*"\shref="([^"]*)"'
 
 
 class LightroomURLProvider(Processor):

--- a/Adobe/LightroomURLProvider.py
+++ b/Adobe/LightroomURLProvider.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2014 
+# Copyright 2014
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -89,7 +89,7 @@ class LightroomURLProvider(Processor):
 			url_handle.close()
 		except BaseException as e:
 			raise ProcessorError("Can't get Lightroom update information for version %s, using check url %s" % (major_version, check_url_version))
-		
+
 		v_match = re.compile(RE_VERSION, re.MULTILINE).search(lua_response)
 
 		if v_match:
@@ -124,7 +124,7 @@ class LightroomURLProvider(Processor):
 
 		product_url = LIGHTROOM_PRODUCT_URL % (major_version, platform, lang)
 		request = urllib2.Request(product_url)
-		
+
 		try:
 			url_handle = urllib2.urlopen(request)
 			html_response = url_handle.read()
@@ -151,7 +151,7 @@ class LightroomURLProvider(Processor):
 			html_response = url_handle.read()
 			url_handle.close()
 		except BaseException as e:
-			raise ProcessorError("Can't get Lightroom download page using url %s" % download_url_fqdn)		
+			raise ProcessorError("Can't get Lightroom download page using url %s" % download_url_fqdn)
 
 
 		dmg_url_match = re.compile(RE_HTML_DOWNLOAD_URL).search(html_response)

--- a/Adobe/LightroomURLProvider.py
+++ b/Adobe/LightroomURLProvider.py
@@ -95,7 +95,7 @@ class LightroomURLProvider(Processor):
             url_handle = urlopen(check_url_version)
             lua_response = url_handle.read()
             url_handle.close()
-        except BaseException as e:
+        except Exception as e:
             raise ProcessorError("Can't get Lightroom update information for version %s, using check url %s" % (major_version, check_url_version))
 
         v_match = re.compile(RE_VERSION, re.MULTILINE).search(lua_response)
@@ -136,7 +136,7 @@ class LightroomURLProvider(Processor):
             url_handle = urlopen(product_url)
             html_response = url_handle.read()
             url_handle.close()
-        except BaseException as e:
+        except Exception as e:
             raise ProcessorError("Can't get Lightroom product page using url %s" % product_url)
 
         # Match the link to the download page
@@ -156,7 +156,7 @@ class LightroomURLProvider(Processor):
             url_handle = urlopen(download_url_fqdn)
             html_response = url_handle.read()
             url_handle.close()
-        except BaseException as e:
+        except Exception as e:
             raise ProcessorError("Can't get Lightroom download page using url %s" % download_url_fqdn)
 
 

--- a/Adobe/LightroomURLProvider.py
+++ b/Adobe/LightroomURLProvider.py
@@ -17,15 +17,18 @@
 from __future__ import absolute_import
 
 import re
-import urllib2
 
 from autopkglib import Processor, ProcessorError
 
 try:
-    from urllib import request as urllib  # For Python 3
+    from urllib.parse import unquote  # For Python 3
 except ImportError:
-    import urllib  # For Python 2
+    from urllib import unquote  # For Python 2
 
+try:
+    from urllib.parse import urlopen  # For Python 3
+except ImportError:
+    from urllib2 import urlopen  # For Python 2
 
 __all__ = ["LightroomURLProvider"]
 
@@ -88,9 +91,8 @@ class LightroomURLProvider(Processor):
 		"""
 
 		check_url_version = check_url % major_version
-		request = urllib2.Request(check_url_version)
 		try:
-			url_handle = urllib2.urlopen(request)
+			url_handle = urlopen(check_url_version)
 			lua_response = url_handle.read()
 			url_handle.close()
 		except BaseException as e:
@@ -129,10 +131,9 @@ class LightroomURLProvider(Processor):
 		"""
 
 		product_url = LIGHTROOM_PRODUCT_URL % (major_version, platform, lang)
-		request = urllib2.Request(product_url)
 
 		try:
-			url_handle = urllib2.urlopen(request)
+			url_handle = urlopen(product_url)
 			html_response = url_handle.read()
 			url_handle.close()
 		except BaseException as e:
@@ -146,14 +147,13 @@ class LightroomURLProvider(Processor):
 		else:
 			raise ProcessorError("Can't get Lightroom download URL from product site.")
 
-		download_url_fqdn = ADOBE_DOWNLOAD_PREFIX + '/' + urllib.unquote(download_url).replace('&amp;', '&')
+		download_url_fqdn = ADOBE_DOWNLOAD_PREFIX + '/' + unquote(download_url).replace('&amp;', '&')
 
 		# ok now we have to get the href of the ACTUAL dmg from the thankyou page, so time to request the download page
 		self.output('Request download page: %s' % download_url_fqdn)
-		request = urllib2.Request(download_url_fqdn)
 
 		try:
-			url_handle = urllib2.urlopen(request)
+			url_handle = urlopen(download_url_fqdn)
 			html_response = url_handle.read()
 			url_handle.close()
 		except BaseException as e:

--- a/Adobe/LightroomURLProvider.py
+++ b/Adobe/LightroomURLProvider.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import re
 import urllib
 import urllib2

--- a/Adobe/LightroomURLProvider.py
+++ b/Adobe/LightroomURLProvider.py
@@ -46,12 +46,12 @@ RE_HTML_DOWNLOAD_URL = '<a class="submit[^"]*"\shref="([^"]*)"'
 
 
 class LightroomURLProvider(Processor):
-	"""Formulate the download url for lightroom and scrape the description.
-	For the moment only the EN language is tested.
+    """Formulate the download url for lightroom and scrape the description.
+    For the moment only the EN language is tested.
 
-	Yes the code sucks, its my first python module.
+    Yes the code sucks, its my first python module.
 
-	Normal update sequence is this:
+    Normal update sequence is this:
     - Lightroom checks at www.adobe.com/go/lightroom_version_5 with UA "Lightroom/5.0"
     - 301 redirect to download.macromedia.com/pub/lightroom/lightroom_version_5.txt
     - Lua(?) script indicates most recent version, download URL, and localized description of the update.
@@ -60,124 +60,124 @@ class LightroomURLProvider(Processor):
     - Download is simply a link to Adobe support downloads webpage. CSS selector:  a.submit
     - Redirects to the actual download page containing another a.submit
     - href is valid if domain contains download.adobe.com ??
-	"""
+    """
 
-	description = "Provides URL to the latest Lightroom release."
-	input_variables = {
-		"language": {
-			"required": False,
-			"description": ("Which language to download. Two letter ISO639 Language code, Examples: 'en', "
-				"'de', 'jp', 'sw'. Default is %s."
-				% LANGUAGE_DEFAULT
-				)
-		},
-		"major_version": {
+    description = "Provides URL to the latest Lightroom release."
+    input_variables = {
+        "language": {
+            "required": False,
+            "description": ("Which language to download. Two letter ISO639 Language code, Examples: 'en', "
+                "'de', 'jp', 'sw'. Default is %s."
+                % LANGUAGE_DEFAULT
+                )
+        },
+        "major_version": {
             "required": False,
             "description": ("Major version. Examples: '10', '11'. Defaults to "
                             "%s" % MAJOR_VERSION_DEFAULT)
         },
-	}
-	output_variables = {
-		"url": {
-			"description": "URL to the latest Lightroom release.",
-		}
-	}
+    }
+    output_variables = {
+        "url": {
+            "description": "URL to the latest Lightroom release.",
+        }
+    }
 
-	__doc__ = description
+    __doc__ = description
 
-	def get_lightroom_update_info(self, check_url, major_version, lang):
-		"""Request lightroom updates LUA script which contains the download URL and localised update string
-		Currently unused
-		"""
+    def get_lightroom_update_info(self, check_url, major_version, lang):
+        """Request lightroom updates LUA script which contains the download URL and localised update string
+        Currently unused
+        """
 
-		check_url_version = check_url % major_version
-		try:
-			url_handle = urlopen(check_url_version)
-			lua_response = url_handle.read()
-			url_handle.close()
-		except BaseException as e:
-			raise ProcessorError("Can't get Lightroom update information for version %s, using check url %s" % (major_version, check_url_version))
+        check_url_version = check_url % major_version
+        try:
+            url_handle = urlopen(check_url_version)
+            lua_response = url_handle.read()
+            url_handle.close()
+        except BaseException as e:
+            raise ProcessorError("Can't get Lightroom update information for version %s, using check url %s" % (major_version, check_url_version))
 
-		v_match = re.compile(RE_VERSION, re.MULTILINE).search(lua_response)
+        v_match = re.compile(RE_VERSION, re.MULTILINE).search(lua_response)
 
-		if v_match:
-			version = v_match.group(1)
-			self.output("Got version %s" % version)
-		else:
-			self.output("Could not find version string on update url")
+        if v_match:
+            version = v_match.group(1)
+            self.output("Got version %s" % version)
+        else:
+            self.output("Could not find version string on update url")
 
-		product_url_match = re.compile(RE_PRODUCT_URL).search(lua_response)
+        product_url_match = re.compile(RE_PRODUCT_URL).search(lua_response)
 
-		if product_url_match:
-			product_url = product_url_match.group(1)
-			self.output("Got product url %s" % product_url)
-		else:
-			raise ProcessorError("Can't get Lightroom product URL from update text.")
+        if product_url_match:
+            product_url = product_url_match.group(1)
+            self.output("Got product url %s" % product_url)
+        else:
+            raise ProcessorError("Can't get Lightroom product URL from update text.")
 
-		description_match = re.compile(RE_LOCAL_DESCRIPTION % lang, re.MULTILINE).search(lua_response)
+        description_match = re.compile(RE_LOCAL_DESCRIPTION % lang, re.MULTILINE).search(lua_response)
 
-		if description_match:
-			update_description = description_match.group(1)
-			self.output("Got update description %s" % update_description)
-		else:
-			self.output("Could not find update description")
-
-
-	def get_lightroom_dmg_url(self, check_url, major_version, platform, lang):
-		"""Get the .dmg url
-
-		Go to the product page, which provides a link to the download page.
-		Then the download page has to be scraped for the dmg link.
-		"""
-
-		product_url = LIGHTROOM_PRODUCT_URL % (major_version, platform, lang)
-
-		try:
-			url_handle = urlopen(product_url)
-			html_response = url_handle.read()
-			url_handle.close()
-		except BaseException as e:
-			raise ProcessorError("Can't get Lightroom product page using url %s" % product_url)
-
-		# Match the link to the download page
-		download_url_match = re.compile(RE_HTML_DOWNLOAD_URL).search(html_response)
-
-		if download_url_match:
-			download_url = download_url_match.group(1)
-		else:
-			raise ProcessorError("Can't get Lightroom download URL from product site.")
-
-		download_url_fqdn = ADOBE_DOWNLOAD_PREFIX + '/' + unquote(download_url).replace('&amp;', '&')
-
-		# ok now we have to get the href of the ACTUAL dmg from the thankyou page, so time to request the download page
-		self.output('Request download page: %s' % download_url_fqdn)
-
-		try:
-			url_handle = urlopen(download_url_fqdn)
-			html_response = url_handle.read()
-			url_handle.close()
-		except BaseException as e:
-			raise ProcessorError("Can't get Lightroom download page using url %s" % download_url_fqdn)
+        if description_match:
+            update_description = description_match.group(1)
+            self.output("Got update description %s" % update_description)
+        else:
+            self.output("Could not find update description")
 
 
-		dmg_url_match = re.compile(RE_HTML_DOWNLOAD_URL).search(html_response)
+    def get_lightroom_dmg_url(self, check_url, major_version, platform, lang):
+        """Get the .dmg url
 
-		if dmg_url_match:
-			dmg_url = dmg_url_match.group(1)
-		else:
-			raise ProcessorError("Can't get Lightroom dmg link")
+        Go to the product page, which provides a link to the download page.
+        Then the download page has to be scraped for the dmg link.
+        """
 
-		return dmg_url
+        product_url = LIGHTROOM_PRODUCT_URL % (major_version, platform, lang)
 
-	def main(self):
-		# Take input params
-		language = self.env.get("lang", LANGUAGE_DEFAULT)
-		major_version = self.env.get("major_version", MAJOR_VERSION_DEFAULT)
-		platform = self.env.get("platform", PLATFORM_DEFAULT)
+        try:
+            url_handle = urlopen(product_url)
+            html_response = url_handle.read()
+            url_handle.close()
+        except BaseException as e:
+            raise ProcessorError("Can't get Lightroom product page using url %s" % product_url)
 
-		self.env["url"] = self.get_lightroom_dmg_url(
-			LIGHTROOM_CHECK_URL, major_version, platform, language)
-		self.output("Found URL %s" % self.env["url"])
+        # Match the link to the download page
+        download_url_match = re.compile(RE_HTML_DOWNLOAD_URL).search(html_response)
+
+        if download_url_match:
+            download_url = download_url_match.group(1)
+        else:
+            raise ProcessorError("Can't get Lightroom download URL from product site.")
+
+        download_url_fqdn = ADOBE_DOWNLOAD_PREFIX + '/' + unquote(download_url).replace('&amp;', '&')
+
+        # ok now we have to get the href of the ACTUAL dmg from the thankyou page, so time to request the download page
+        self.output('Request download page: %s' % download_url_fqdn)
+
+        try:
+            url_handle = urlopen(download_url_fqdn)
+            html_response = url_handle.read()
+            url_handle.close()
+        except BaseException as e:
+            raise ProcessorError("Can't get Lightroom download page using url %s" % download_url_fqdn)
+
+
+        dmg_url_match = re.compile(RE_HTML_DOWNLOAD_URL).search(html_response)
+
+        if dmg_url_match:
+            dmg_url = dmg_url_match.group(1)
+        else:
+            raise ProcessorError("Can't get Lightroom dmg link")
+
+        return dmg_url
+
+    def main(self):
+        # Take input params
+        language = self.env.get("lang", LANGUAGE_DEFAULT)
+        major_version = self.env.get("major_version", MAJOR_VERSION_DEFAULT)
+        platform = self.env.get("platform", PLATFORM_DEFAULT)
+
+        self.env["url"] = self.get_lightroom_dmg_url(
+            LIGHTROOM_CHECK_URL, major_version, platform, language)
+        self.output("Found URL %s" % self.env["url"])
 
 
 if __name__ == "__main__":

--- a/Adobe/LightroomURLProvider.py
+++ b/Adobe/LightroomURLProvider.py
@@ -15,11 +15,17 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import re
-import urllib
 import urllib2
 
 from autopkglib import Processor, ProcessorError
+
+try:
+    from urllib import request as urllib  # For Python 3
+except ImportError:
+    import urllib  # For Python 2
+
 
 __all__ = ["LightroomURLProvider"]
 

--- a/EFI/HypatiaProvider.py
+++ b/EFI/HypatiaProvider.py
@@ -14,10 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-from __future__ import print_function
-from xml.etree import ElementTree
-import urllib
+from __future__ import absolute_import, print_function
+
 import urllib2
 
 from autopkglib import Processor, ProcessorError

--- a/EFI/HypatiaProvider.py
+++ b/EFI/HypatiaProvider.py
@@ -84,24 +84,24 @@ def _new_software_request(product_id, host_id=12345, os_name='Mac OS X', os_vers
     attr 3 fsm_version=4.0.0.30|uid=88f11a1df1e02ae493f8e6d9f7eb1288|os_version=10.12.6|os_type=mac|os_lang=en_GB|check_mode=manual|fsm_pref=NotifyAll|installed_products=cws:5.8.0.39,frs:6.4.0.21,sp_cws:2,sp_frs:2,sp_hf:2|clean_install=0
     """
     req = '''
-<soap:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"> 
-<soap:Body> 
-    <newSoftware xmlns="http://updates.efi.com/des/"> 
-        <product_identifier>{product_identifier}</product_identifier> 
-        <host_id>{host_id}</host_id> 
-        <os_name>{os_name}</os_name> 
-        <os_version>{os_version}</os_version> 
-        <os_image_version>{os_image_version}</os_image_version> 
-        <software_version>{software_version}</software_version> 
-        <software_language>{software_language}</software_language> 
-        <custom_attribute1>CodeBase</custom_attribute1> 
-        <custom_attribute2 /> 
-        <custom_attribute3 /> 
-        <custom_attribute4 /> 
-        <installed_updates> 
-        </installed_updates> 
-    </newSoftware> 
-</soap:Body> 
+<soap:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+<soap:Body>
+    <newSoftware xmlns="http://updates.efi.com/des/">
+        <product_identifier>{product_identifier}</product_identifier>
+        <host_id>{host_id}</host_id>
+        <os_name>{os_name}</os_name>
+        <os_version>{os_version}</os_version>
+        <os_image_version>{os_image_version}</os_image_version>
+        <software_version>{software_version}</software_version>
+        <software_language>{software_language}</software_language>
+        <custom_attribute1>CodeBase</custom_attribute1>
+        <custom_attribute2 />
+        <custom_attribute3 />
+        <custom_attribute4 />
+        <installed_updates>
+        </installed_updates>
+    </newSoftware>
+</soap:Body>
 </soap:Envelope>
     '''
     return req.format(

--- a/EFI/HypatiaProvider.py
+++ b/EFI/HypatiaProvider.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
+from __future__ import print_function
 from xml.etree import ElementTree
 import urllib
 import urllib2
@@ -153,7 +155,7 @@ class HypatiaProvider(Processor):
         # except BaseException as e:
         #     raise ProcessorError("Can't get download URL for EFI Product ID: %s" % self.env['product_id'])
 
-        print html_response
+        print(html_response)
 
 
 if __name__ == "__main__":

--- a/EFI/HypatiaProvider.py
+++ b/EFI/HypatiaProvider.py
@@ -150,7 +150,7 @@ class HypatiaProvider(Processor):
         url_handle = urllib2.urlopen(request, request_content)
         html_response = url_handle.read()
         url_handle.close()
-        # except BaseException as e:
+        # except Exception as e:
         #     raise ProcessorError("Can't get download URL for EFI Product ID: %s" % self.env['product_id'])
 
         print(html_response)

--- a/JetBrains/JetbrainsURLProvider.py
+++ b/JetBrains/JetbrainsURLProvider.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import re
 import urllib
 import urllib2

--- a/JetBrains/JetbrainsURLProvider.py
+++ b/JetBrains/JetbrainsURLProvider.py
@@ -17,9 +17,13 @@
 from __future__ import absolute_import
 
 import json
-import urllib2
 
 from autopkglib import Processor, ProcessorError
+
+try:
+    from urllib.parse import urlopen  # For Python 3
+except ImportError:
+    from urllib2 import urlopen  # For Python 2
 
 __all__ = ["JetbrainsURLProvider"]
 
@@ -111,10 +115,9 @@ class JetbrainsURLProvider(Processor):
     def xhr_release_info(self, product_code):
         """Request release information from JetBrains XHR Endpoint"""
         url = RELEASE_XHR_ENDPOINT.format(product_code, "123123123")
-        request = urllib2.Request(url)
 
         try:
-            handle = urllib2.urlopen(request)
+            handle = urlopen(url)
             response = handle.read()
             handle.close()
         except BaseException as e:

--- a/JetBrains/JetbrainsURLProvider.py
+++ b/JetBrains/JetbrainsURLProvider.py
@@ -15,10 +15,9 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-import re
-import urllib
-import urllib2
+
 import json
+import urllib2
 
 from autopkglib import Processor, ProcessorError
 

--- a/JetBrains/JetbrainsURLProvider.py
+++ b/JetBrains/JetbrainsURLProvider.py
@@ -120,7 +120,7 @@ class JetbrainsURLProvider(Processor):
             handle = urlopen(url)
             response = handle.read()
             handle.close()
-        except BaseException as e:
+        except Exception as e:
             raise ProcessorError("Cannot retrieve product information from JetBrains")
 
         product_info = json.loads(response)

--- a/Processors/FlatPkgVersioner.py
+++ b/Processors/FlatPkgVersioner.py
@@ -16,12 +16,13 @@
 # See: https://github.com/munki/munki/blob/master/code/client/munkilib/munkicommon.py#L1507
 
 from __future__ import absolute_import
-import os
-import tempfile
-import subprocess
-import shutil
 
+import os
+import shutil
+import subprocess
+import tempfile
 from glob import glob
+
 from autopkglib import ProcessorError
 from DmgMounter import DmgMounter
 

--- a/Processors/FlatPkgVersioner.py
+++ b/Processors/FlatPkgVersioner.py
@@ -15,6 +15,7 @@
 # Basically copied line for line and adapted from Greg Neagle's Munki project.
 # See: https://github.com/munki/munki/blob/master/code/client/munkilib/munkicommon.py#L1507
 
+from __future__ import absolute_import
 import os
 import tempfile
 import subprocess

--- a/XRite/MunkiReceiptEditor.py
+++ b/XRite/MunkiReceiptEditor.py
@@ -13,8 +13,10 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-from autopkglib import Processor, ProcessorError
+
 import FoundationPlist
+from autopkglib import Processor, ProcessorError
+
 
 class MunkiReceiptEditor(Processor):
     description = "Modify receipt information after PkgInfo has been generated"

--- a/XRite/MunkiReceiptEditor.py
+++ b/XRite/MunkiReceiptEditor.py
@@ -51,14 +51,14 @@ class MunkiReceiptEditor(Processor):
             return {}
         try:
             return FoundationPlist.readPlist(pathname)
-        except BaseException as err:
+        except Exception as err:
             raise ProcessorError(
                 'Could not read %s: %s' % (pathname, err))
 
     def writePlist(self, data, pathname):
         try:
             FoundationPlist.writePlist(data, pathname)
-        except BaseException as err:
+        except Exception as err:
             raise ProcessorError(
                 'Could not write %s: %s' % (pathname, err))
 

--- a/XRite/MunkiReceiptEditor.py
+++ b/XRite/MunkiReceiptEditor.py
@@ -69,7 +69,7 @@ class MunkiReceiptEditor(Processor):
 
         for receipt in pkginfo["receipts"]:
             if 'packageid' in receipt and receipt['packageid'] == packageid:
-                if self.env.get("optional") == True:
+                if self.env.get("optional") is True:
                     receipt['optional'] = True
                     self.output("Made package id %s optional" % packageid)
 

--- a/XRite/MunkiReceiptEditor.py
+++ b/XRite/MunkiReceiptEditor.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 from autopkglib import Processor, ProcessorError
 import FoundationPlist
 
@@ -48,14 +49,14 @@ class MunkiReceiptEditor(Processor):
             return {}
         try:
             return FoundationPlist.readPlist(pathname)
-        except Exception, err:
+        except Exception as err:
             raise ProcessorError(
                 'Could not read %s: %s' % (pathname, err))
 
     def writePlist(self, data, pathname):
         try:
             FoundationPlist.writePlist(data, pathname)
-        except Exception, err:
+        except Exception as err:
             raise ProcessorError(
                 'Could not write %s: %s' % (pathname, err))
 

--- a/XRite/MunkiReceiptEditor.py
+++ b/XRite/MunkiReceiptEditor.py
@@ -49,14 +49,14 @@ class MunkiReceiptEditor(Processor):
             return {}
         try:
             return FoundationPlist.readPlist(pathname)
-        except Exception as err:
+        except BaseException as err:
             raise ProcessorError(
                 'Could not read %s: %s' % (pathname, err))
 
     def writePlist(self, data, pathname):
         try:
             FoundationPlist.writePlist(data, pathname)
-        except Exception as err:
+        except BaseException as err:
             raise ProcessorError(
                 'Could not write %s: %s' % (pathname, err))
 


### PR DESCRIPTION
In order to make your processors more compatible with AutoPkg running in Python 3, I've applied a few adjustments suggested by `python-modernize`, `pylint --py3k`, and `pylint` in general.

More adjustments may need to be made manually later (including the `urllib2` usage in HypatiaProvider), but this should catch the low-hanging fruit right now.