### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-autopkg-recipes
-===============
+# mosen-recipes
 
-## The repo has moved ##
-The new location is at https://github.com/autopkg/mosen-recipes
-
+Recipes for [AutoPkg](https://github.com/autopkg/autopkg)


### PR DESCRIPTION
"Repo has moved" link points to itself, so it's not really needed.