### PR TITLE
Adjust JetBrains product codes and use URLGetter superclass for downloads

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+repos:
+- repo: https://github.com/homebysix/pre-commit-macadmin
+  rev: v1.6.1
+  hooks:
+  - id: check-autopkg-recipes
+    args: ['--recipe-prefix', 'com.github.mosen.']
+  - id: forbid-autopkg-overrides
+  - id: forbid-autopkg-trust-info
+  - id: check-plists
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v2.3.0
+  hooks:
+  - id: check-added-large-files
+    args: ['--maxkb=100']
+  - id: check-ast
+  - id: check-byte-order-marker
+  - id: check-case-conflict
+  - id: check-docstring-first
+  - id: check-merge-conflict
+  - id: mixed-line-ending
+  - id: check-xml
+  - id: check-yaml
+  # - id: check-executables-have-shebangs
+  # - id: end-of-file-fixer
+  # - id: fix-encoding-pragma
+  # - id: trailing-whitespace

--- a/JetBrains/JetbrainsURLProvider.py
+++ b/JetBrains/JetbrainsURLProvider.py
@@ -48,7 +48,7 @@ PRODUCT_CODES = {
     "dotTraceProfilingSDK": "DPPS",
     "hub": "HB",
     "IntelliJ IDEA Ultimate": "IIU",
-    "IntelliJ IDEA Standard": "II",
+    "IntelliJ IDEA Community": "IIC",
     "mps": "MPS",
     "mpsIntelliJIDEAPlugin": "MPSIIP",
     "PyCharm Professional": "PCP",

--- a/JetBrains/JetbrainsURLProvider.py
+++ b/JetBrains/JetbrainsURLProvider.py
@@ -62,11 +62,11 @@ PRODUCT_CODES = {
     "ReSharper Ultimate": "RSU",
     "TeamCity": "TC",
     "WebStorm": "WS",
-    "YouTrack": "YT",
+    "YouTrack": "YT",  # Not a valid product code as of 2020-01-11.
     "YouTrack Standalone": "YTD",
     "YouTrack Workflow Editor": "YTWE",
     "UpSource": "US",
-    "0xDBE": "DBE",
+    "0xDBE": "DBE",  # Not a valid product code as of 2020-01-11.
     "DataGrip": "DG",
 }
 

--- a/JetBrains/JetbrainsURLProvider.py
+++ b/JetBrains/JetbrainsURLProvider.py
@@ -51,7 +51,6 @@ PRODUCT_CODES = {
     "IntelliJ IDEA Standard": "II",
     "mps": "MPS",
     "mpsIntelliJIDEAPlugin": "MPSIIP",
-    "PyCharm": "PC",
     "PyCharm Professional": "PCP",
     "PyCharm Community": "PCC",
     "PyCharm EDU": "PCE",

--- a/JetBrains/JetbrainsURLProvider.py
+++ b/JetBrains/JetbrainsURLProvider.py
@@ -18,12 +18,8 @@ from __future__ import absolute_import
 
 import json
 
-from autopkglib import Processor, ProcessorError
+from autopkglib import Processor, ProcessorError, URLGetter
 
-try:
-    from urllib.request import urlopen  # For Python 3
-except ImportError:
-    from urllib2 import urlopen  # For Python 2
 
 __all__ = ["JetbrainsURLProvider"]
 
@@ -72,42 +68,38 @@ PRODUCT_CODES = {
     "YouTrack Workflow Editor": "YTWE",
     "UpSource": "US",
     "0xDBE": "DBE",
-    "DataGrip": "DG"
+    "DataGrip": "DG",
 }
 
 RELEASE_XHR_ENDPOINT = "https://data.services.jetbrains.com/products/releases?code={0}&latest=true&type=release&_={1}"
 
 
 DEFAULT_PRODUCT = "IntelliJ IDEA"
-DEFAULT_CODE = PRODUCT_CODES["IntelliJ IDEA Ultimate"]  # Only used for IDEA IU=Ultimate, IC=Community
+DEFAULT_CODE = PRODUCT_CODES[
+    "IntelliJ IDEA Ultimate"
+]  # Only used for IDEA IU=Ultimate, IC=Community
 DEFAULT_PLATFORM = "mac"
 
 
-class JetbrainsURLProvider(Processor):
+class JetbrainsURLProvider(URLGetter):
     description = "Provides URL to the latest JetBrains IDE release"
     input_variables = {
         "product_code": {
             "required": True,
-            "description": "The product code. AppCode=AC, CLion=CL, IDEA Ultimate=IIU, PyCharm Pro=PCP, PhpStorm=PS, RubyMine=RM, WebStorm=WS"
+            "description": "The product code. AppCode=AC, CLion=CL, IDEA Ultimate=IIU, PyCharm Pro=PCP, PhpStorm=PS, RubyMine=RM, WebStorm=WS",
         },
         "platform": {
             "required": False,
-            "description": "[optional] The operating system platform, one of 'mac', 'windows', 'linux'"
-        }
+            "description": "[optional] The operating system platform, one of 'mac', 'windows', 'linux'",
+        },
     }
     output_variables = {
-        "url": {
-            "description": "URL to the latest JetBrains IDE release",
-        },
-        "version": {
-            "description": "Product version",
-        },
+        "url": {"description": "URL to the latest JetBrains IDE release",},
+        "version": {"description": "Product version",},
         "majorVersion": {
             "description": "Product major version, usually first two numbers",
         },
-        "build": {
-            "description": "Product build number",
-        }
+        "build": {"description": "Product build number",},
     }
 
     __doc__ = description
@@ -115,17 +107,9 @@ class JetbrainsURLProvider(Processor):
     def xhr_release_info(self, product_code):
         """Request release information from JetBrains XHR Endpoint"""
         url = RELEASE_XHR_ENDPOINT.format(product_code, "123123123")
-
-        try:
-            handle = urlopen(url)
-            response = handle.read()
-            handle.close()
-        except Exception as e:
-            raise ProcessorError("Cannot retrieve product information from JetBrains")
-
+        response = self.download(url)
         product_info = json.loads(response)
         return product_info[product_code][0]
-
 
     def main(self):
         product_code = self.env.get("product_code", DEFAULT_CODE)

--- a/JetBrains/JetbrainsURLProvider.py
+++ b/JetBrains/JetbrainsURLProvider.py
@@ -49,6 +49,7 @@ PRODUCT_CODES = {
     "hub": "HB",
     "IntelliJ IDEA Ultimate": "IIU",
     "IntelliJ IDEA Community": "IIC",
+    "IntelliJ IDEA EDU": "IIE",
     "mps": "MPS",
     "mpsIntelliJIDEAPlugin": "MPSIIP",
     "PyCharm Professional": "PCP",


### PR DESCRIPTION
This PR makes some adjustments to the JetBrains product code dictionary and adds support for the new [URLGetter](https://github.com/autopkg/autopkg/wiki/Downloading-from-the-Internet-in-Custom-Processors) superclass.

AutoPkg verbose run logs: https://gist.github.com/homebysix/13fb34f031e3002eb9b252fdf266a0c6