### PR TITLE
Add pkg recipe for improved JAMF installs

### DIFF
--- a/JetBrains/IDEA-IU.jss.recipe
+++ b/JetBrains/IDEA-IU.jss.recipe
@@ -29,6 +29,8 @@
   <string>0.4.0</string>
   <key>ParentRecipe</key>
   <string>com.github.mosen.download.IDEA-IU</string>
+  <key>ParentRecipe</key>
+  <string>com.github.mosen.pkg.IDEA-IU</string>
   <key>Process</key>
   <array>
     <dict>

--- a/JetBrains/IDEA-IU.pkg.recipe
+++ b/JetBrains/IDEA-IU.pkg.recipe
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>Description</key>
+		<string>Downloads the current release version of IDEA Ultimate and creates a package.</string>
+		<key>Identifier</key>
+		<string>com.github.mosen.pkg.IDEA-IU</string>
+		<key>Input</key>
+		<dict>
+			<key>NAME</key>
+			<string>IDEA-IU</string>
+		</dict>
+		<key>MinimumVersion</key>
+		<string>0.2.5</string>
+		<key>ParentRecipe</key>
+		<string>com.github.mosen.download.IDEA-IU</string>
+		<key>Process</key>
+		<array>
+			<dict>
+				<key>Processor</key>
+				<string>AppDmgVersioner</string>
+				<key>Arguments</key>
+				<dict>
+					<key>dmg_path</key>
+					<string>%pathname%</string>
+				</dict>
+			</dict>
+			<dict>
+				<key>Processor</key>
+				<string>PkgRootCreator</string>
+				<key>Arguments</key>
+				<dict>
+					<key>pkgroot</key>
+					<string>%RECIPE_CACHE_DIR%/%NAME%</string>
+					<key>pkgdirs</key>
+					<dict>
+						<key>Applications</key>
+						<string>0775</string>
+					</dict>
+				</dict>
+			</dict>
+			<dict>
+				<key>Processor</key>
+				<string>Copier</string>
+				<key>Arguments</key>
+				<dict>
+					<key>source_path</key>
+					<string>%pathname%/IntelliJ IDEA.app</string>
+					<key>destination_path</key>
+					<string>%pkgroot%/Applications/IntelliJ IDEA.app</string>
+				</dict>
+			</dict>
+
+			<dict>
+				<key>Processor</key>
+				<string>PkgCreator</string>
+				<key>Arguments</key>
+				<dict>
+					<key>pkg_request</key>
+					<dict>
+						<key>pkgname</key>
+						<string>%NAME%-%version%</string>
+						<key>version</key>
+						<string>%version%</string>
+						<key>id</key>
+						<string>com.idea-iu</string>
+						<key>options</key>
+						<string>purge_ds_store</string>
+						<key>chown</key>
+						<array>
+							<dict>
+								<key>path</key>
+								<string>Applications</string>
+								<key>user</key>
+								<string>root</string>
+								<key>group</key>
+								<string>admin</string>
+							</dict>
+						</array>
+					</dict>
+				</dict>
+			</dict>
+		</array>
+	</dict>
+</plist>


### PR DESCRIPTION
I noticed when using the JSS recipe that the installer being uploaded to JAMF was the original JetBrains DMG file, which JAMF doesn't know how to work with. These files need to be repackaged into PKG installers for JAMF, so I added a PKG recipe and added it as a parent in the JSS recipe. Works perfectly in my testing, I derived it from an existing PKG recipe for RubyMine. Let me know if you have any feedback.

Thank you!