### PR TITLE
Adjust name of CodeSignatureVerifier argument

### DIFF
--- a/ItsApparent/BarcodeProducer.download.recipe
+++ b/ItsApparent/BarcodeProducer.download.recipe
@@ -44,7 +44,7 @@
 			<dict>
 				<key>input_path</key>
 				<string>%RECIPE_CACHE_DIR%/Barcode Producer.app</string>
-				<key>requirements</key>
+				<key>requirement</key>
 				<string>identifier "com.barcodeproducer.barcodeproducer" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = XLRYTV33X4</string>
 			</dict>
 		</dict>


### PR DESCRIPTION
The correct argument name for [CodeSignatureVerifier](https://github.com/autopkg/autopkg/wiki/Processor-CodeSignatureVerifier) is `requirement`.