### PR TITLE
Adjust PkgCreator arguments

### DIFF
--- a/Mozilla/FirefoxESRPolicies.pkg.recipe
+++ b/Mozilla/FirefoxESRPolicies.pkg.recipe
@@ -111,9 +111,9 @@
                         <string>purge_ds_store</string>
                         <key>pkgdir</key>
                         <string>%RECIPE_CACHE_DIR%</string>
+                        <key>pkgname</key>
+                        <string>%NAME%_%ORG_NAME%-%version%</string>
                     </dict>
-                    <key>pkgname</key>
-                    <string>%NAME%_%ORG_NAME%-%version%</string>
                 </dict>
                 <key>Processor</key>
                 <string>PkgCreator</string>


### PR DESCRIPTION
`pkgname` is [intended](https://github.com/autopkg/autopkg/blob/e36d5cba2823dbdfcb69a41a38b1aef9fb76121c/Code/autopkgserver/autopkgserver#L47) to be in the `pkg_request` dictionary, not as a standalone argument for [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator).