### PR TITLE
Small key description tweak for `macM1` platform

### DIFF
--- a/JetBrains/JetbrainsURLProvider.py
+++ b/JetBrains/JetbrainsURLProvider.py
@@ -91,7 +91,7 @@ class JetbrainsURLProvider(URLGetter):
         },
         "platform": {
             "required": False,
-            "description": "[optional] The operating system platform, one of 'mac', 'windows', 'linux'",
+            "description": "[optional] The operating system platform, one of 'mac', 'macM1', 'windows', 'linux'",
         },
     }
     output_variables = {


### PR DESCRIPTION
This is a small tweak to the `description` of the `platform` key which explictly denotes the proper `platform` value for using this provider for retrieving JetBrains packages for M1/Apple Silicon/ARM64 architectures.