### PR TITLE
update versioning for salt

### DIFF
--- a/SaltStack/salt-py3.download.recipe
+++ b/SaltStack/salt-py3.download.recipe
@@ -23,7 +23,7 @@
 				<key>url</key>
 				<string>https://repo.saltstack.com/#osx</string>
 				<key>re_pattern</key>
-				<string>Latest release: ([\d\.]+)</string>
+				<string>osx\/salt\-([\d\.\\-]+)\-py3-x86_64.pkg</string>
 				<key>result_output_var_name</key>
 				<string>version</string>
 			</dict>


### PR DESCRIPTION
Salt changed the versioning pattern to include package builds. This change will adapt accordingly. 