### PR TITLE
Fix salt.download.recipe

### DIFF
--- a/SaltStack/salt.download.recipe
+++ b/SaltStack/salt.download.recipe
@@ -24,18 +24,31 @@ in the PYVERSION variable to switch between 2 (default) and 3 versions of the in
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>https://repo.saltstack.com/#osx</string>
+				<string>https://repo.saltproject.io/#osx</string>
 				<key>re_pattern</key>
 				<string>Latest release: ([\d\.]+)</string>
 				<key>result_output_var_name</key>
 				<string>version</string>
 			</dict>
 		</dict>
+        <dict>
+            <key>Processor</key>
+            <string>URLTextSearcher</string>
+            <key>Arguments</key>
+            <dict>
+                <key>url</key>
+                <string>https://repo.saltproject.io/#osx</string>
+                <key>re_pattern</key>
+                <string>href="(https://repo.saltproject.io/osx/salt-%version%.*%PYVERSION%-x86_64\.pkg)"</string>
+                <key>result_output_var_name</key>
+                <string>url</string>
+            </dict>
+        </dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>https://repo.saltstack.com/osx/salt-%version%-py%PYVERSION%-x86_64.pkg</string>
+				<string>%url%</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
- Account for current situation where package name includes `%version%-1` to continue have downloads working
- User new saltproject URL scheme