### PR TITLE
Deprecate Salt recipes

### DIFF
--- a/SaltStack/salt-py3.download.recipe
+++ b/SaltStack/salt-py3.download.recipe
@@ -17,6 +17,15 @@
 	<array>
 		<dict>
 			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>The Salt Project is no longer building macOS packages (details: https://saltproject.io/blog/streamlining-cicd-package-distribution/). This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
 			<string>URLTextSearcher</string>
 			<key>Arguments</key>
 			<dict>

--- a/SaltStack/salt.download.recipe
+++ b/SaltStack/salt.download.recipe
@@ -20,6 +20,15 @@ in the PYVERSION variable to switch between 2 (default) and 3 versions of the in
 	<array>
 		<dict>
 			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>The Salt Project is no longer building macOS packages (details: https://saltproject.io/blog/streamlining-cicd-package-distribution/). This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
 			<string>URLTextSearcher</string>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
This PR deprecates Salt recipes, since the Salt Project is no longer building macOS packages ([details](https://saltproject.io/blog/streamlining-cicd-package-distribution/)).
