### PR TITLE
Deprecate fseventer recipes

### DIFF
--- a/FernLightning/Fseventer.download.recipe
+++ b/FernLightning/Fseventer.download.recipe
@@ -16,9 +16,18 @@
         <string>http://www.fernlightning.com/appcasts/fseventer.xml</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Fseventer is no longer available for download. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>SparkleUpdateInfoProvider</string>


### PR DESCRIPTION
This PR deprecates the fseventer recipes, since the software is no longer available for download.
