### PR TITLE
Deprecate FontExplorerX recipes

### DIFF
--- a/Linotype/FontExplorerX4Plugins.download.recipe
+++ b/Linotype/FontExplorerX4Plugins.download.recipe
@@ -23,6 +23,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>FontExplorerX plugins are no longer available for download (details: https://www.fontexplorerx.com/). This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>SparkleUpdateInfoProvider</string>
             <key>Arguments</key>
             <dict>

--- a/Linotype/FontExplorerXPro.download.recipe
+++ b/Linotype/FontExplorerXPro.download.recipe
@@ -27,9 +27,18 @@
         <string>https://www.fontexplorerx.com/download/free-trial/Mac</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>FontExplorerX is no longer available for download (details: https://www.fontexplorerx.com/). This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>URLDownloader</string>

--- a/Linotype/FontExplorerXServer.download.recipe
+++ b/Linotype/FontExplorerXServer.download.recipe
@@ -23,6 +23,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>FontExplorerX Server is no longer available for download (details: https://www.fontexplorerx.com/). This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
This PR deprecates the FontExplorerX and related recipes, since the software is no longer available for download.
