### PR TITLE
Deprecate CADTools 7-9 recipes and update description for CADTools 10

### DIFF
--- a/HotDoor/CADTools10.download.recipe
+++ b/HotDoor/CADTools10.download.recipe
@@ -4,7 +4,7 @@
 <dict>
     <key>Description</key>
     <string>
-    Download the specified version of HotDoor CADtools
+    Download the specified version of HotDoor CADtools. Tested with version 10, 11, 12, 13, and 14.
     </string>
     <key>Identifier</key>
     <string>com.github.mosen.download.CADtools10</string>

--- a/HotDoor/CADTools10.munki.recipe
+++ b/HotDoor/CADTools10.munki.recipe
@@ -26,9 +26,9 @@
                 <string>testing</string>
             </array>
             <key>description</key>
-            <string>HotDoor CADtools 10 for Illustrator</string>
+            <string>HotDoor CADtools %VERSION% for Illustrator</string>
             <key>display_name</key>
-            <string>CADtools 10</string>
+            <string>CADtools %VERSION%</string>
             <key>name</key>
             <string>%NAME%</string>
             <key>unattended_install</key>
@@ -51,7 +51,7 @@
             <key>Arguments</key>
             <dict>
                 <key>pkg_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/Hot Door CADtools 10/Install CADtools 10.pkg</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/Hot Door CADtools %VERSION%/Install CADtools %VERSION%.pkg</string>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
             </dict>

--- a/HotDoor/CADTools7.download.recipe
+++ b/HotDoor/CADTools7.download.recipe
@@ -20,9 +20,18 @@
         <string>.dmg.zip</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>CADTools 7-9 is no longer available for download. Consider switching to the CADTools10 recipes in this repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>URLDownloader</string>

--- a/HotDoor/CADTools8.download.recipe
+++ b/HotDoor/CADTools8.download.recipe
@@ -20,9 +20,18 @@
         <string>.dmg.zip</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>CADTools 7-9 is no longer available for download. Consider switching to the CADTools10 recipes in this repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>URLDownloader</string>

--- a/HotDoor/CADTools9.download.recipe
+++ b/HotDoor/CADTools9.download.recipe
@@ -20,9 +20,18 @@
         <string>.dmg.zip</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>CADTools 7-9 is no longer available for download. Consider switching to the CADTools10 recipes in this repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>URLDownloader</string>


### PR DESCRIPTION
This PR deprecates CADTools 7-9 recipes, which no longer work. It also updates the CADTools 10 recipe to make clearer that it supports more recent versions too.
