### PR TITLE
Deprecate 0xED recipes

### DIFF
--- a/SuaveTech/0xED.download.recipe
+++ b/SuaveTech/0xED.download.recipe
@@ -17,9 +17,18 @@
         <string>http://www.suavetech.com/cgi-bin/download.cgi?0xED.tar.bz2</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>0xED is no longer available for download. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>URLDownloader</string>


### PR DESCRIPTION
This PR deprecates the 0xED recipes, since the software is no longer available for download.
