### PR TITLE
Deprecate SeafileClient recipes

### DIFF
--- a/Seafile/SeafileClient.download.recipe
+++ b/Seafile/SeafileClient.download.recipe
@@ -12,9 +12,18 @@
         <string>SeafileClient</string>
     </dict>
     <key>MinimumVersion</key>
-    <string>0.2.0</string>
+    <string>1.1</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the SeafileClient recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>URLTextSearcher</string>


### PR DESCRIPTION
The SeafileClient recipes in this repo are redundant with the ones offered in dataJAR-recipes, and the dataJAR versions offer code signature verification, which is a good practice. This PR deprecates the SeafileClient recipes in this repo.
