### PR TITLE
20251122-fix-endofcheckphase

### DIFF
--- a/EFI/FieryExtendedApplications.download.recipe
+++ b/EFI/FieryExtendedApplications.download.recipe
@@ -25,6 +25,10 @@
             <key>Processor</key>
             <string>URLDownloader</string>
         </dict>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
     </array>
 </dict>
 </plist>

--- a/ItsApparent/BarcodeProducer.download.recipe
+++ b/ItsApparent/BarcodeProducer.download.recipe
@@ -28,6 +28,10 @@
                 <string>%NAME%.zip</string>
             </dict>
         </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
 		<dict>
 			<key>Processor</key>
 			<string>Unarchiver</string>
@@ -48,10 +52,6 @@
 				<string>identifier "com.barcodeproducer.barcodeproducer" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = XLRYTV33X4</string>
 			</dict>
 		</dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
     </array>
 </dict>
 </plist>

--- a/JetBrains/IDEA-IU.download.recipe
+++ b/JetBrains/IDEA-IU.download.recipe
@@ -33,6 +33,10 @@
             <string>URLDownloader</string>
         </dict>
         <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
 			<key>Arguments</key>
 			<dict>
 				<key>dmg_path</key>
@@ -51,10 +55,6 @@
                 <key>requirement</key>
                 <string>identifier "com.jetbrains.intellij" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2ZEFAR8TH3"</string>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>

--- a/JetBrains/PhpStorm.download.recipe
+++ b/JetBrains/PhpStorm.download.recipe
@@ -33,6 +33,10 @@
             <string>URLDownloader</string>
         </dict>
         <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
 			<key>Arguments</key>
 			<dict>
 				<key>dmg_path</key>
@@ -51,10 +55,6 @@
                 <key>requirement</key>
                 <string>identifier "com.jetbrains.PhpStorm" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2ZEFAR8TH3"</string>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>

--- a/JetBrains/PyCharmPro.download.recipe
+++ b/JetBrains/PyCharmPro.download.recipe
@@ -33,6 +33,10 @@
             <string>URLDownloader</string>
         </dict>
         <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
 			<key>Arguments</key>
 			<dict>
 				<key>dmg_path</key>
@@ -51,10 +55,6 @@
                 <key>requirement</key>
                 <string>identifier "com.jetbrains.pycharm" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2ZEFAR8TH3"</string>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>

--- a/JetBrains/RubyMine.download.recipe
+++ b/JetBrains/RubyMine.download.recipe
@@ -33,6 +33,10 @@
             <string>URLDownloader</string>
         </dict>
         <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
 			<key>Arguments</key>
 			<dict>
 				<key>dmg_path</key>
@@ -51,10 +55,6 @@
                 <key>requirement</key>
                 <string>identifier "com.jetbrains.rubymine" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2ZEFAR8TH3"</string>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>

--- a/JetBrains/WebStorm.download.recipe
+++ b/JetBrains/WebStorm.download.recipe
@@ -33,6 +33,10 @@
             <string>URLDownloader</string>
         </dict>
         <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
 			<key>Arguments</key>
 			<dict>
 				<key>dmg_path</key>
@@ -51,10 +55,6 @@
                 <key>requirement</key>
                 <string>identifier "com.jetbrains.WebStorm" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2ZEFAR8TH3"</string>
             </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
         </dict>
     </array>
 </dict>

--- a/JetBrains/jetbrains.download.recipe
+++ b/JetBrains/jetbrains.download.recipe
@@ -37,6 +37,10 @@
 			<string>URLDownloader</string>
 		</dict>
 		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>dmg_path</key>
@@ -55,10 +59,6 @@
 				<key>requirement</key>
 				<string>identifier "%PRODUCT_IDENTIFIER%" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2ZEFAR8TH3"</string>
 			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>EndOfCheckPhase</string>
 		</dict>
 	</array>
 </dict>

--- a/XRite/i1Profiler.download.recipe
+++ b/XRite/i1Profiler.download.recipe
@@ -43,6 +43,10 @@
         </dict>
         <dict>
             <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>Unarchiver</string>
             <key>Arguments</key>
             <dict>
@@ -67,10 +71,6 @@
 				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.pkg</string>
 			</dict>
 		</dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
     </array>
 </dict>
 </plist>


### PR DESCRIPTION
In order to use AutoPkg with the `--check` argument, download recipes must include an `EndOfCheckPhase` processor. This processor indicates where to stop processing when checking for new downloaded files. The proper placement of the processor is directly after the last `URLDownloader` or `URLDownloaderPython` processor to eliminate unnecessary processing (such as a code signature verification of an unchanged file).

This pull request adds the `EndOfCheckPhase` processor if is is missing and moves it to the correct location if it already exists.

Thanks for considering!

This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0.