### PR TITLE
Update all available URLs from HTTP to HTTPS

### DIFF
--- a/Adobe/AdobeAcrobatProBaseCustomized.pkg.recipe
+++ b/Adobe/AdobeAcrobatProBaseCustomized.pkg.recipe
@@ -58,7 +58,7 @@ from CCP can be used.
             <key>Arguments</key>
             <dict>
                 <key>url</key>
-                <string>http://ardownload.adobe.com/pub/adobe/acrobat/mac/AcrobatDC/misc/AdobeCustomizationWizard1500720033_DC.dmg</string>
+                <string>https://ardownload.adobe.com/pub/adobe/acrobat/mac/AcrobatDC/misc/AdobeCustomizationWizard1500720033_DC.dmg</string>
                 <key>request_headers</key>
                 <dict>
                     <key>User-Agent</key>

--- a/Adobe/CustomizationWizardXI.download.recipe
+++ b/Adobe/CustomizationWizardXI.download.recipe
@@ -15,7 +15,7 @@
         <key>NAME</key>
         <string>CustomizationWizardXI</string>
         <key>DOWNLOAD_URL</key>
-        <string>http://ardownload.adobe.com/pub/adobe/acrobat/mac/11.x/11.0.00/misc/AdobeCustomizationWizard11000.dmg</string>
+        <string>https://ardownload.adobe.com/pub/adobe/acrobat/mac/11.x/11.0.00/misc/AdobeCustomizationWizard11000.dmg</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.0</string>

--- a/Centrify/CentrifyDC.download.recipe
+++ b/Centrify/CentrifyDC.download.recipe
@@ -18,9 +18,9 @@
         <key>NAME</key>
         <string>CentrifyDC</string>
         <key>CENTRIFY_DOWNLOAD_URL</key>
-        <string>http://www.centrify.com/support/download.asp?asset=</string>
+        <string>https://www.centrify.com/support/download.asp?asset=</string>
         <key>SUPPORT_CENTER_URL</key>
-        <string>http://www.centrify.com/support/mac-support-center.asp</string>
+        <string>https://www.centrify.com/support/mac-support-center.asp</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.0</string>

--- a/Esko/InkTools.download.recipe
+++ b/Esko/InkTools.download.recipe
@@ -15,7 +15,7 @@
         <key>NAME</key>
         <string>InkTools</string>
         <key>url</key>
-        <string>http://cdn.mysoftware.esko.com/downloads/Public/Trials/Latest/InkToolsTrial_16.0.0.396.dmg</string>
+        <string>https://cdn.mysoftware.esko.com/downloads/Public/Trials/Latest/InkToolsTrial_16.0.0.396.dmg</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.0</string>

--- a/Esko/PowerLayout.download.recipe
+++ b/Esko/PowerLayout.download.recipe
@@ -15,7 +15,7 @@
         <key>NAME</key>
         <string>PowerTrapper</string>
         <key>url</key>
-        <string>http://cdn.mysoftware.esko.com/downloads/Public/Trials/Latest/PowerLayout_Trial_16_0_0_66.dmg</string>
+        <string>https://cdn.mysoftware.esko.com/downloads/Public/Trials/Latest/PowerLayout_Trial_16_0_0_66.dmg</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.0</string>

--- a/Esko/PowerTrapper.download.recipe
+++ b/Esko/PowerTrapper.download.recipe
@@ -15,7 +15,7 @@
         <key>NAME</key>
         <string>PowerTrapper</string>
         <key>url</key>
-        <string>http://cdn.mysoftware.esko.com/downloads/Public/Trials/Latest/PowerTrapper_Trial_16_0_0_66.dmg</string>
+        <string>https://cdn.mysoftware.esko.com/downloads/Public/Trials/Latest/PowerTrapper_Trial_16_0_0_66.dmg</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.0</string>

--- a/Xerox/FieryEX550_560.download.recipe
+++ b/Xerox/FieryEX550_560.download.recipe
@@ -15,7 +15,7 @@
         <key>NAME</key>
         <string>FieryEX550_560</string>
         <key>DOWNLOAD_URL</key>
-        <string>http://download.support.xerox.com/pub/drivers/XRIP_550_Fiery/drivers/macosx106/da/XC_EX560_v2_0_R_EFIGSBpDX_FD45_v1.dmg</string>
+        <string>https://download.support.xerox.com/pub/drivers/XRIP_550_Fiery/drivers/macosx106/da/XC_EX560_v2_0_R_EFIGSBpDX_FD45_v1.dmg</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.0</string>

--- a/Xerox/FieryEX550_560_ElCapitan.download.recipe
+++ b/Xerox/FieryEX550_560_ElCapitan.download.recipe
@@ -14,7 +14,7 @@
         <key>NAME</key>
         <string>FieryEX550_560_ElCapitan</string>
         <key>url</key>
-        <string>http://download.support.xerox.com/pub/drivers/550_560_DCP/drivers/macosx1011/en_GB/FIT101142635.zip</string>
+        <string>https://download.support.xerox.com/pub/drivers/550_560_DCP/drivers/macosx1011/en_GB/FIT101142635.zip</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.0</string>

--- a/Xerox/FieryEX550_560_Yosemite.download.recipe
+++ b/Xerox/FieryEX550_560_Yosemite.download.recipe
@@ -16,7 +16,7 @@
         <key>NAME</key>
         <string>FieryEX550_560_Yosemite</string>
         <key>DOWNLOAD_URL</key>
-        <string>http://download.support.xerox.com/pub/drivers/550_560_DCP/drivers/macosx1010/nl/Mac_os_10_10_ex560_2_0.zip</string>
+        <string>https://download.support.xerox.com/pub/drivers/550_560_DCP/drivers/macosx1010/nl/Mac_os_10_10_ex560_2_0.zip</string>
     </dict>
     <key>MinimumVersion</key>
     <string>0.2.0</string>


### PR DESCRIPTION
It's important to use HTTPS for downloading software whenever possible in order to avoid the possibility of person-in-the-middle attacks (like the one that affected the Sparkle update framework [in January 2016](https://vulnsec.com/2016/osx-apps-vulnerabilities/)).

For this pull request, I detected and changed to HTTPS URLs automatically using my [HTTPS Spotter](https://www.elliotjordan.com/posts/autopkg-https/) script, and then tested all changed recipes manually to ensure exit codes of recipe run remains the same before/after the change.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.3.0._